### PR TITLE
Enable encodings autodetect on TextLoader

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ RAGify Search is an AI-powered intelligent assistant built with Streamlit, desig
    streamlit run ./src/app.py
    ```
 
+4. **langchain ollama requirement**
+	```bash
+	ollama pull nomic-embed-text
+	```
+
 ---
 
 ## Usage

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ langchain-core
 langchain-ollama
 streamlit
 urllib3
+chardet

--- a/src/prompt_generator.py
+++ b/src/prompt_generator.py
@@ -9,10 +9,12 @@ from web_scraper import decode_filename_to_url, remove_temp_files
 from config import CHUNK_OVERLAP, CHUNK_SIZE
 
 def load_documents(download_dir: str = "./downloaded") -> list[Document]:
+    text_loader_kwargs={'autodetect_encoding': True}
     loader = DirectoryLoader(
         download_dir,
         use_multithreading=True,
-        loader_cls=TextLoader)
+        loader_cls=TextLoader,
+        loader_kwargs=text_loader_kwargs)
     return loader.load()
 
 def split_documents(documents):


### PR DESCRIPTION
Add missing requirement

This change handles the Exception:
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 4628: character maps to <undefined>

As a note this was on Windows so it was trying to use cp1252 as the encoding.